### PR TITLE
guard against `undefined` interpolations

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -165,4 +165,14 @@ describe('stream-template', function () {
 
     out.destroy();
   });
+
+  it('should handle undefined interpolations', function (done) {
+    var name = 'tom';
+    var test = undefined;
+    var out = ST`Hello ${name}, welcome to the ${test} test`;
+    out.pipe(concat(function (output) {
+      expect(output.toString()).equal('Hello tom, welcome to the  test');
+      done();
+    }));
+  })
 });


### PR DESCRIPTION
This is a relatively small change to guard against passing `undefined` or `null` interpolations (it unfortunately touches several code lines due to wrapping in outer conditional). There were two locations where a `.pipe` check would throw for `undefined` or `null`, so I added a null check where appropriate.

(btw, thanks for a great library! More people should know about this)